### PR TITLE
Pin the influx/grafana versions

### DIFF
--- a/setup/influxdb/docker-compose.yml
+++ b/setup/influxdb/docker-compose.yml
@@ -1,5 +1,5 @@
 influxdb:
-  image: influxdb:latest
+  image: influxdb:1.8.4
   container_name: influxdb
   ports:
     - 8086:8086
@@ -9,7 +9,7 @@ influxdb:
     always
 
 grafana:
-  image: grafana/grafana
+  image: grafana/grafana:7.4.0
   container_name: grafana
   ports:
     - 3001:3000


### PR DESCRIPTION
To avoid problems with newest versions of the influxdb/grafana being pulled by docker-compose, pin the versions to
- influxdb: 1.8.4
- grafana: 7.4.0