### PR TITLE
DEV: add `cancel` order functionality

### DIFF
--- a/async_exchange/orders.py
+++ b/async_exchange/orders.py
@@ -1,11 +1,20 @@
+from uuid import uuid4
+
+
 class _Order:
     def __init__(self, owner, amount, price):
         self.owner = owner
         self.amount = amount
         self.price = price
 
+        self._id = uuid4()
+
     def __repr__(self):
         return f"Trader {self.owner._id} {self.action} {self.amount}"
+
+    @property
+    def id(self):
+        return self._id
 
 
 class BuyOrder(_Order):

--- a/async_exchange/trader.py
+++ b/async_exchange/trader.py
@@ -1,4 +1,4 @@
-from async_exchange.orders import BuyOrder, SellOrder
+from async_exchange.orders import BuyOrder, SellOrder, _Order
 
 
 class NotEnoughMoneyError(ValueError):
@@ -61,6 +61,29 @@ class Trader:
 
     def inspect_exchange(self):
         return self.exchange_api.get_orderbook()
+
+    @property
+    def standing_orders(self):
+        """ Get two tuples of standing orders from ``self``.
+        """
+        return self.exchange_api.standing_orders(self)
+
+    def cancel_order(self, order: _Order) -> bool:
+        """ Cancel the ``order``: the order will be removed from the
+        exchange's order book. If the ``order`` has been successfully
+        removed, returns ``True``. If the ``order`` cannot be removed,
+        returns ``False``.
+        """
+        return self.exchange_api.cancel_order(order)
+
+    def cancel_all_orders(self) -> bool:
+        """ Cancel all orders the ``_Trader`` has submitted. Returns
+        ``True`` iif all standing orders have been successfully removed.
+        """
+        buy_orders, sell_orders = self.standing_orders
+        return all(
+            self.cancel_order(order) for order in buy_orders + sell_orders
+        )
 
     def __str__(self):
         return f"Trader {self._id}: stocks {self.stocks}, cash {self.money}"

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -80,6 +80,109 @@ class TestTrader(unittest.TestCase):
         buy_order, = self.exchange.buy_levels[12]
         self.assertIs(self.trader, buy_order.owner)
 
+    def test_standing_orders(self):
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
+        self.trader.buy(amount=20, price=10)
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 1)
+        buy_order, = buy_orders
+        self.assertEqual(buy_order.price, 10)
+        self.assertEqual(buy_order.amount, 20)
+        self.assertEqual(len(sell_orders), 0)
+
+        self.trader.sell(amount=30, price=40)
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 1)
+        buy_order, = buy_orders
+        self.assertEqual(buy_order.price, 10)
+        self.assertEqual(buy_order.amount, 20)
+        self.assertEqual(len(sell_orders), 1)
+        sell_order, = sell_orders
+        self.assertEqual(sell_order.price, 40)
+        self.assertEqual(sell_order.amount, 30)
+
+    def test_cancel_order_buy(self):
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
+        self.trader.buy(amount=20, price=10)
+        (buy_order,), _ = self.trader.standing_orders
+
+        result = self.trader.cancel_order(buy_order)
+        self.assertTrue(result)
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
+        result = self.trader.cancel_order(buy_order)
+        self.assertFalse(result)
+
+    def test_cancel_order_sell(self):
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
+        self.trader.sell(amount=20, price=10)
+        _, (sell_order,) = self.trader.standing_orders
+
+        result = self.trader.cancel_order(sell_order)
+        self.assertTrue(result)
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
+        result = self.trader.cancel_order(sell_order)
+        self.assertFalse(result)
+
+    def test_cancel_order_many_orders(self):
+        self.trader.sell(amount=10, price=40)
+        self.trader.sell(amount=20, price=30)
+        self.trader.buy(amount=30, price=20)
+        self.trader.buy(amount=40, price=10)
+
+        (buy_order_1, buy_order_2), (
+            sell_order_1,
+            sell_order_2,
+        ) = self.trader.standing_orders
+
+        result = self.trader.cancel_order(buy_order_2)
+        self.assertTrue(result)
+        (actual_buy_order_1,), (
+            actual_sell_order_1,
+            actual_sell_order_2,
+        ) = self.trader.standing_orders
+        self.assertIs(actual_buy_order_1, buy_order_1)
+        self.assertIs(actual_sell_order_1, sell_order_1)
+        self.assertIs(actual_sell_order_2, sell_order_2)
+
+        result = self.trader.cancel_order(sell_order_1)
+        self.assertTrue(result)
+        (actual_buy_order_1,), (
+            actual_sell_order_2,
+        ) = self.trader.standing_orders
+        self.assertIs(actual_buy_order_1, buy_order_1)
+        self.assertIs(actual_sell_order_2, sell_order_2)
+
+    def test_cancel_all_orders(self):
+        self.trader.sell(amount=10, price=40)
+        self.trader.sell(amount=20, price=30)
+        self.trader.buy(amount=30, price=20)
+        self.trader.buy(amount=40, price=10)
+
+        (buy_order_1, buy_order_2), (
+            sell_order_1,
+            sell_order_2,
+        ) = self.trader.standing_orders
+
+        self.trader.cancel_all_orders()
+        buy_orders, sell_orders = self.trader.standing_orders
+        self.assertEqual(len(buy_orders), 0)
+        self.assertEqual(len(sell_orders), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[ Closes ] #22

- [x] All necessary tests are included
- [x] All necessary documentation changes are included

### Summary
<!-- Self-consistent description of the suggested improvements. -->

Add an `id` property to the `_Order` (`uuid.uuid4()`, generated on instantiation)

Introduce an `ExchangeAPI` method to cancel order by `_Order.id`. This is provided by the new `Exchange.cancel_order` method.

Introduce convenience methods to the `Trader` class:
- `standing_orders` (property; returns all pending buy/sell orders of the trader object) 
- `cancel` (single order)
- `cancel_all_orders`